### PR TITLE
Now parametrization "on-fly" of JSON files is allowed using env vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ basic description. For more info run docker with `--help` option:
 
 # JSON expected formats #
 
+Before describe allowed _JSON_ formats is important to note that values of
+**environment variables** can be replaced _on-fly_ **in files**.
+
+Any string with `{{ENV_VAR_NAME}}` found in any json file will be replaced by
+value of `ENV_VAR_NAME` **only** if `ENV_VAR_NAME` is defined.
+
 ## New user
 
 This is an example of a valid JSON to create new user:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     #   GRAFANA_ENDPOINT: "http://grafana:3000"
     #   # ENV GRAFANA_AUTH_BEARER:
     #   GRAFANA_AUTH_USERPASSWD: "admin:admin1234"
+      # Replacement values "in-files"
+      PASSWORD_FOR_KUSER: "kpassword_from_env"
     volumes:
       - ./test:/data
     command:

--- a/test/users/k.json
+++ b/test/users/k.json
@@ -2,5 +2,5 @@
   "name": "k",
   "email": "k@t.com",
   "login": "k",
-  "password": "kpassword"
+  "password": "{{PASSWORD_FOR_KUSER}}"
 }


### PR DESCRIPTION
`{{ENV_VAR_NAME}}` occurrences in files used to upload data to _Grafana_ will be replaced _on-fly_ for value of `ENV_VAR_NAME` environment var only if it is defined (not empty: `""`).